### PR TITLE
[improve] Allow user-specified S3 path

### DIFF
--- a/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/BlobStoreAbstractConfig.java
@@ -115,6 +115,7 @@ public class BlobStoreAbstractConfig implements Serializable {
     private String bytesFormatTypeSeparator = "0x10";
     private boolean skipFailedMessages = false;
     private boolean jsonAllowNaN = false;
+    private String topicsToPathMapping;
 
     public void validate() {
         checkNotNull(provider, "provider not set.");
@@ -187,6 +188,10 @@ public class BlobStoreAbstractConfig implements Serializable {
         checkArgument(pendingQueueSize > 0, "pendingQueueSize must be a positive integer.");
         checkArgument(pendingQueueSize >= batchSize, "pendingQueueSize must be larger than or "
                 + "equal to batchSize");
+
+        if (StringUtils.isNotEmpty(topicsToPathMapping)) {
+            validateTopicsToPathMapping();
+        }
     }
 
     private static boolean hasURIScheme(String endpoint) {
@@ -195,6 +200,22 @@ public class BlobStoreAbstractConfig implements Serializable {
             return isNotBlank(uri.getScheme());
         } catch (URISyntaxException e) {
             return false;
+        }
+    }
+
+    public void validateTopicsToPathMapping() {
+        for (String topicToPathMapping : topicsToPathMapping.split(",")) {
+            String[] topicPathPair = topicToPathMapping.split("=");
+            checkArgument(topicPathPair.length == 2,
+                    "Invalid topicsToPathMapping format: " + topicToPathMapping);
+            String topic = topicPathPair[0].trim();
+            String path = topicPathPair[1].trim();
+            checkArgument(isNotBlank(topic), "Topic in topicsToPathMapping cannot be empty.");
+            checkArgument(isNotBlank(path), "Path in topicsToPathMapping cannot be empty.");
+            checkArgument(topic.matches("^[^/]+/[^/]+/[^/]+$"),
+                    "Topic must be in the format 'tenant/ns/topic': " + topic);
+            checkArgument(!path.startsWith("/") && !path.endsWith("/"),
+                    "Path in topicsToPathMapping cannot starts or ends with '/': " + path);
         }
     }
 

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java
@@ -18,9 +18,13 @@
  */
 package org.apache.pulsar.io.jcloud.partitioner;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.common.naming.TopicName;
@@ -42,35 +46,67 @@ public abstract class AbstractPartitioner<T> implements Partitioner<T> {
     private boolean withTopicPartitionNumber;
     private boolean useIndexAsOffset;
 
+    private Map<String, String> topicsToPathMapping;
+    private Map<String, String> computedTopicsToPathMapping;
+
+
     @Override
     public void configure(BlobStoreAbstractConfig config) {
         this.sliceTopicPartitionPath = config.isSliceTopicPartitionPath();
         this.withTopicPartitionNumber = config.isWithTopicPartitionNumber();
         this.useIndexAsOffset = config.isPartitionerUseIndexAsOffset();
+        this.topicsToPathMapping = parseTopicsToPathMappingString(config.getTopicsToPathMapping());
+        this.computedTopicsToPathMapping = new HashMap<>();
+    }
+
+    private Map<String, String> parseTopicsToPathMappingString(String topicsToPathMappingString) {
+        Map<String, String> topicsToPathMapping = new HashMap<>();
+        if (StringUtils.isNotEmpty(topicsToPathMappingString)) {
+            for (String topicPathPair : topicsToPathMappingString.split(",")) {
+                String[] topicToPathMapping = topicPathPair.split("=");
+                if (topicToPathMapping.length == 2) {
+                    topicsToPathMapping.put(topicToPathMapping[0], topicToPathMapping[1]);
+                } else {
+                    LOGGER.warn("The topic to path mapping is not in correct format {}.", topicPathPair);
+                }
+            }
+        }
+        LOGGER.info("The final topics to path mapping is: {}", topicsToPathMapping);
+        return topicsToPathMapping;
     }
 
     @Override
     public String generatePartitionedPath(String topic, String encodedPartition) {
+        if (MapUtils.isNotEmpty(computedTopicsToPathMapping) && computedTopicsToPathMapping.containsKey(topic)) {
+            return StringUtils.join(Arrays.asList(computedTopicsToPathMapping.get(topic), encodedPartition),
+                    PATH_SEPARATOR);
+        } else {
+            List<String> joinList = new ArrayList<>();
+            TopicName topicName = TopicName.get(topic);
+            joinList.add(topicName.getTenant());
+            joinList.add(topicName.getNamespacePortion());
 
-        List<String> joinList = new ArrayList<>();
-        TopicName topicName = TopicName.get(topic);
-        joinList.add(topicName.getTenant());
-        joinList.add(topicName.getNamespacePortion());
-
-        if (topicName.isPartitioned() && withTopicPartitionNumber) {
-            if (sliceTopicPartitionPath) {
+            if (topicName.isPartitioned() && withTopicPartitionNumber) {
+                if (sliceTopicPartitionPath) {
+                    TopicName newTopicName = TopicName.get(topicName.getPartitionedTopicName());
+                    joinList.add(newTopicName.getLocalName());
+                    joinList.add(Integer.toString(topicName.getPartitionIndex()));
+                } else {
+                    joinList.add(topicName.getLocalName());
+                }
+            } else {
                 TopicName newTopicName = TopicName.get(topicName.getPartitionedTopicName());
                 joinList.add(newTopicName.getLocalName());
-                joinList.add(Integer.toString(topicName.getPartitionIndex()));
-            } else {
-                joinList.add(topicName.getLocalName());
             }
-        } else {
-            TopicName newTopicName = TopicName.get(topicName.getPartitionedTopicName());
-            joinList.add(newTopicName.getLocalName());
+            String generatedTopicPath = StringUtils.join(joinList, PATH_SEPARATOR);
+            if (MapUtils.isNotEmpty(topicsToPathMapping) && topicsToPathMapping.containsKey(generatedTopicPath)) {
+                joinList.clear();
+                joinList.add(topicsToPathMapping.get(generatedTopicPath));
+            }
+            computedTopicsToPathMapping.put(topic, StringUtils.join(joinList, PATH_SEPARATOR));
+            joinList.add(encodedPartition);
+            return StringUtils.join(joinList, PATH_SEPARATOR);
         }
-        joinList.add(encodedPartition);
-        return StringUtils.join(joinList, PATH_SEPARATOR);
     }
 
     protected long getMessageOffset(Record<T> record) {

--- a/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/partitioner/AbstractPartitioner.java
@@ -18,13 +18,11 @@
  */
 package org.apache.pulsar.io.jcloud.partitioner;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.common.naming.TopicName;
@@ -48,7 +46,6 @@ public abstract class AbstractPartitioner<T> implements Partitioner<T> {
 
     private Map<String, String> topicsToPathMapping;
     private Map<String, String> computedTopicsToPathMapping;
-
 
     @Override
     public void configure(BlobStoreAbstractConfig config) {
@@ -77,9 +74,8 @@ public abstract class AbstractPartitioner<T> implements Partitioner<T> {
 
     @Override
     public String generatePartitionedPath(String topic, String encodedPartition) {
-        if (MapUtils.isNotEmpty(computedTopicsToPathMapping) && computedTopicsToPathMapping.containsKey(topic)) {
-            return StringUtils.join(Arrays.asList(computedTopicsToPathMapping.get(topic), encodedPartition),
-                    PATH_SEPARATOR);
+        if (computedTopicsToPathMapping.containsKey(topic)) {
+            return String.format("%s%s%s", computedTopicsToPathMapping.get(topic), PATH_SEPARATOR, encodedPartition);
         } else {
             List<String> joinList = new ArrayList<>();
             TopicName topicName = TopicName.get(topic);
@@ -99,7 +95,7 @@ public abstract class AbstractPartitioner<T> implements Partitioner<T> {
                 joinList.add(newTopicName.getLocalName());
             }
             String generatedTopicPath = StringUtils.join(joinList, PATH_SEPARATOR);
-            if (MapUtils.isNotEmpty(topicsToPathMapping) && topicsToPathMapping.containsKey(generatedTopicPath)) {
+            if (topicsToPathMapping.containsKey(generatedTopicPath)) {
                 joinList.clear();
                 joinList.add(topicsToPathMapping.get(generatedTopicPath));
             }

--- a/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
+++ b/src/main/java/org/apache/pulsar/io/jcloud/sink/BlobStoreAbstractSink.java
@@ -353,10 +353,10 @@ public abstract class BlobStoreAbstractSink<V extends BlobStoreAbstractConfig> i
 
         String encodePartition = partitioner.encodePartition(message, partitioningTimestamp);
         String partitionedPath = partitioner.generatePartitionedPath(message.getTopicName().get(), encodePartition);
-        String generatedTopicPath = partitionedPath.replace(PATH_SEPARATOR + encodePartition, StringUtils.EMPTY);
-        if (isTopicToPathMappingExists(generatedTopicPath)) {
-            String mappedPath = topicsToPathMapping.get(generatedTopicPath);
-            partitionedPath = StringUtils.join(Arrays.asList(mappedPath, encodePartition), PATH_SEPARATOR);
+        String trimmedTopicPath = partitionedPath.replace(PATH_SEPARATOR + encodePartition, StringUtils.EMPTY);
+        if (isTopicToPathMappingExists(trimmedTopicPath)) {
+            String topicMappedPath = topicsToPathMapping.get(trimmedTopicPath);
+            partitionedPath = StringUtils.join(Arrays.asList(topicMappedPath, encodePartition), PATH_SEPARATOR);
         }
         String path = pathPrefix + partitionedPath + format.getExtension();
         log.info("generate message[recordSequence={}] savePath: {}", message.getRecordSequence().get(), path);

--- a/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/ConnectorConfigTest.java
@@ -50,6 +50,7 @@ public class ConnectorConfigTest {
         config.put("timePartitionPattern", "yyyy-MM-dd");
         config.put("timePartitionDuration", "2d");
         config.put("batchSize", 10);
+        config.put("topicsToPathMapping", "my-tenant/my-ns/topic1=path-mytopic1,my-tenant/my-ns/topic2=path-mytopic2");
         CloudStorageSinkConfig cloudStorageSinkConfig = CloudStorageSinkConfig.load(config);
         cloudStorageSinkConfig.validate();
 
@@ -65,6 +66,7 @@ public class ConnectorConfigTest {
         Assert.assertEquals(config.get("batchSize"), cloudStorageSinkConfig.getBatchSize());
         Assert.assertEquals((int) config.get("batchSize"), cloudStorageSinkConfig.getPendingQueueSize());
         Assert.assertEquals(10000000L, cloudStorageSinkConfig.getMaxBatchBytes());
+        Assert.assertEquals(config.get("topicsToPathMapping"), cloudStorageSinkConfig.getTopicsToPathMapping());
     }
 
     @Test
@@ -121,6 +123,77 @@ public class ConnectorConfigTest {
 
         try {
             config.put("timePartitionDuration", "1000y");
+            CloudStorageSinkConfig.load(config).validate();
+            Assert.fail();
+        } catch (Exception e) {
+        }
+    }
+
+    @Test
+    public void topicsToPathMappingTest() throws IOException {
+        Map<String, Object> config = new HashMap<>();
+        config.put("provider", PROVIDER_AWSS3);
+        config.put("accessKeyId", "aws-s3");
+        config.put("secretAccessKey", "aws-s3");
+        config.put("bucket", "testbucket");
+        config.put("region", "localhost");
+        config.put("endpoint", "https://us-standard");
+        config.put("formatType", "avro");
+        config.put("partitionerType", "default");
+        config.put("timePartitionPattern", "yyyy-MM-dd");
+        config.put("timePartitionDuration", "2d");
+        config.put("batchSize", 10);
+        try {
+            config.put("topicsToPathMapping", "tenant1/ns1/topic1=path-mytopic1,tenant1/ns1/topic2=path-mytopic2");
+            CloudStorageSinkConfig.load(config).validate();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        try {
+            config.put("topicsToPathMapping", "topic1=path-mytopic1");
+            CloudStorageSinkConfig.load(config).validate();
+            Assert.fail();
+        } catch (Exception e) {
+        }
+
+        try {
+            config.put("topicsToPathMapping", "tenant1/=path-mytopic1");
+            CloudStorageSinkConfig.load(config).validate();
+            Assert.fail();
+        } catch (Exception e) {
+        }
+
+        try {
+            config.put("topicsToPathMapping", "tenant1/ns1=path-mytopic1");
+            CloudStorageSinkConfig.load(config).validate();
+            Assert.fail();
+        } catch (Exception e) {
+        }
+
+        try {
+            config.put("topicsToPathMapping", "tenant1/ns1/topic1=path-mytopic1,tenant1/ns1/topic2=");
+            CloudStorageSinkConfig.load(config).validate();
+            Assert.fail();
+        } catch (Exception e) {
+        }
+
+        try {
+            config.put("topicsToPathMapping", "tenant1/ns1/topic1=path-mytopic1,=path-mytopic2");
+            CloudStorageSinkConfig.load(config).validate();
+            Assert.fail();
+        } catch (Exception e) {
+        }
+
+        try {
+            config.put("topicsToPathMapping", "tenant1/ns1/topic1=/path-mytopic1");
+            CloudStorageSinkConfig.load(config).validate();
+            Assert.fail();
+        } catch (Exception e) {
+        }
+
+        try {
+            config.put("topicsToPathMapping", "tenant1/ns1/topic1=path-mytopic1/");
             CloudStorageSinkConfig.load(config).validate();
             Assert.fail();
         } catch (Exception e) {

--- a/src/test/java/org/apache/pulsar/io/jcloud/partitioner/TopicsToPathMappingPartitionerTest.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/partitioner/TopicsToPathMappingPartitionerTest.java
@@ -1,0 +1,255 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.jcloud.partitioner;
+
+import com.google.common.base.Supplier;
+import junit.framework.TestCase;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.functions.api.Record;
+import org.apache.pulsar.io.jcloud.BlobStoreAbstractConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.text.MessageFormat;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * partitioner unit test.
+ */
+@RunWith(Parameterized.class)
+public class TopicsToPathMappingPartitionerTest extends TestCase {
+
+    @Parameterized.Parameter(0)
+    public Partitioner<Object> partitioner;
+
+    @Parameterized.Parameter(1)
+    public String expected;
+
+    @Parameterized.Parameter(2)
+    public String expectedPartitionedPath;
+
+    @Parameterized.Parameter(3)
+    public Record<Object> pulsarRecord;
+
+    @Parameterized.Parameters
+    public static Object[][] data() {
+        BlobStoreAbstractConfig blobStoreAbstractConfig1 = new BlobStoreAbstractConfig();
+        blobStoreAbstractConfig1.setTimePartitionDuration("1d");
+        blobStoreAbstractConfig1.setTimePartitionPattern("yyyy-MM-dd");
+        blobStoreAbstractConfig1.setSliceTopicPartitionPath(false);
+        blobStoreAbstractConfig1.setWithTopicPartitionNumber(false);
+        blobStoreAbstractConfig1.setTopicsToPathMapping("public/default/test=path1," +
+                "public/default/test-partition-1=path2,public/default/test/1=path3");
+        SimplePartitioner<Object> simplePartitioner1 = new SimplePartitioner<>();
+        simplePartitioner1.configure(blobStoreAbstractConfig1);
+        TimePartitioner<Object> dayPartitioner1 = new TimePartitioner<>();
+        dayPartitioner1.configure(blobStoreAbstractConfig1);
+
+        BlobStoreAbstractConfig blobStoreAbstractConfig2 = new BlobStoreAbstractConfig();
+        blobStoreAbstractConfig2.setTimePartitionDuration("1d");
+        blobStoreAbstractConfig2.setTimePartitionPattern("yyyy-MM-dd");
+        blobStoreAbstractConfig2.setSliceTopicPartitionPath(false);
+        blobStoreAbstractConfig2.setWithTopicPartitionNumber(true);
+        blobStoreAbstractConfig2.setTopicsToPathMapping("public/default/test=path1," +
+                "public/default/test-partition-1=path2,public/default/test/1=path3");
+        SimplePartitioner<Object> simplePartitioner2 = new SimplePartitioner<>();
+        simplePartitioner2.configure(blobStoreAbstractConfig2);
+        TimePartitioner<Object> dayPartitioner2 = new TimePartitioner<>();
+        dayPartitioner2.configure(blobStoreAbstractConfig2);
+
+        BlobStoreAbstractConfig blobStoreAbstractConfig3 = new BlobStoreAbstractConfig();
+        blobStoreAbstractConfig3.setTimePartitionDuration("1d");
+        blobStoreAbstractConfig3.setTimePartitionPattern("yyyy-MM-dd");
+        blobStoreAbstractConfig3.setSliceTopicPartitionPath(true);
+        blobStoreAbstractConfig3.setWithTopicPartitionNumber(false);
+        blobStoreAbstractConfig3.setTopicsToPathMapping("public/default/test=path1," +
+                "public/default/test-partition-1=path2,public/default/test/1=path3");
+        SimplePartitioner<Object> simplePartitioner3 = new SimplePartitioner<>();
+        simplePartitioner3.configure(blobStoreAbstractConfig3);
+        TimePartitioner<Object> dayPartitioner3 = new TimePartitioner<>();
+        dayPartitioner3.configure(blobStoreAbstractConfig3);
+
+        BlobStoreAbstractConfig blobStoreAbstractConfig4 = new BlobStoreAbstractConfig();
+        blobStoreAbstractConfig4.setTimePartitionDuration("1d");
+        blobStoreAbstractConfig4.setTimePartitionPattern("yyyy-MM-dd");
+        blobStoreAbstractConfig4.setSliceTopicPartitionPath(true);
+        blobStoreAbstractConfig4.setWithTopicPartitionNumber(true);
+        blobStoreAbstractConfig4.setTopicsToPathMapping("public/default/test=path1," +
+                "public/default/test-partition-1=path2,public/default/test/1=path3");
+        SimplePartitioner<Object> simplePartitioner4 = new SimplePartitioner<>();
+        simplePartitioner4.configure(blobStoreAbstractConfig4);
+        TimePartitioner<Object> dayPartitioner4 = new TimePartitioner<>();
+        dayPartitioner4.configure(blobStoreAbstractConfig4);
+
+        return new Object[][]{
+                new Object[]{
+                        simplePartitioner1,
+                        "3221225506",
+                        "path1" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getTopic()
+                },
+                new Object[]{
+                        dayPartitioner1,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "path1/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getTopic()
+                },
+                new Object[]{
+                        simplePartitioner1,
+                        "3221225506",
+                        "path1" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
+                new Object[]{
+                        dayPartitioner1,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "path1/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
+                new Object[]{
+                        simplePartitioner2,
+                        "3221225506",
+                        "path1" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getTopic()
+                },
+                new Object[]{
+                        dayPartitioner2,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "path1/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getTopic()
+                },
+                new Object[]{
+                        simplePartitioner2,
+                        "3221225506",
+                        "path2" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
+                new Object[]{
+                        dayPartitioner2,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "path2/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
+                new Object[]{
+                        simplePartitioner3,
+                        "3221225506",
+                        "path1" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getTopic()
+                },
+                new Object[]{
+                        dayPartitioner3,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "path1/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getTopic()
+                },
+                new Object[]{
+                        simplePartitioner3,
+                        "3221225506",
+                        "path1" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
+                new Object[]{
+                        dayPartitioner3,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "path1/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
+                new Object[]{
+                        simplePartitioner4,
+                        "3221225506",
+                        "path1" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getTopic()
+                },
+                new Object[]{
+                        dayPartitioner4,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "path1/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getTopic()
+                },
+                new Object[]{
+                        simplePartitioner4,
+                        "3221225506",
+                        "path3" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
+                new Object[]{
+                        dayPartitioner4,
+                        "2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        "path3/2020-09-08" + Partitioner.PATH_SEPARATOR + "3221225506",
+                        getPartitionedTopic()
+                },
+        };
+    }
+
+    public static Record<byte[]> getPartitionedTopic() {
+        @SuppressWarnings("unchecked")
+        Message<byte[]> mock = mock(Message.class);
+        when(mock.getPublishTime()).thenReturn(1599578218610L);
+        when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
+        String topic = TopicName.get("test-partition-1").toString();
+        Record<byte[]> mockRecord = mock(Record.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        return mockRecord;
+    }
+
+    public static Record<Object> getTopic() {
+        @SuppressWarnings("unchecked")
+        Message<Object> mock = mock(Message.class);
+        when(mock.getPublishTime()).thenReturn(1599578218610L);
+        when(mock.getMessageId()).thenReturn(new MessageIdImpl(12, 34, 1));
+        String topic = TopicName.get("test").toString();
+        Record<Object> mockRecord = mock(Record.class);
+        when(mockRecord.getTopicName()).thenReturn(Optional.of(topic));
+        when(mockRecord.getPartitionIndex()).thenReturn(Optional.of(1));
+        when(mockRecord.getMessage()).thenReturn(Optional.of(mock));
+        when(mockRecord.getPartitionId()).thenReturn(Optional.of(String.format("%s-%s", topic, 1)));
+        when(mockRecord.getRecordSequence()).thenReturn(Optional.of(3221225506L));
+        return mockRecord;
+    }
+
+    @Test
+    public void testEncodePartition() {
+        String encodePartition = partitioner.encodePartition(pulsarRecord, System.currentTimeMillis());
+        Supplier<String> supplier =
+                () -> MessageFormat.format("expected: {0}\nactual: {1}", expected, encodePartition);
+        Assert.assertEquals(supplier.get(), expected, encodePartition);
+    }
+
+    @Test
+    public void testGeneratePartitionedPath() {
+        String encodePartition = partitioner.encodePartition(pulsarRecord, System.currentTimeMillis());
+        String partitionedPath =
+                partitioner.generatePartitionedPath(pulsarRecord.getTopicName().get(), encodePartition);
+
+        Supplier<String> supplier =
+                () -> MessageFormat.format("expected: {0}\nactual: {1}", expected, encodePartition);
+        Assert.assertEquals(supplier.get(), expectedPartitionedPath, partitionedPath);
+    }
+}


### PR DESCRIPTION
### Motivation

To allow the user-specified path with the help of topics to path mappings from the user.
### Modifications

Added a mapping field to allow the user to specify topics to path mapping. Based on the mapping path, the topics data will be uploaded to s3.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
