### PR TITLE
Upgrade Parquet to 1.15.1 to address CVE-2025-30065 in master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
     <lombok.version>1.18.20</lombok.version>
     <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
-    <parquet.version>1.12.2</parquet.version>
+    <parquet.version>1.15.1</parquet.version>
     <awsjavasdk.version>1.12.148</awsjavasdk.version>
     <aws.java.sdk2.version>2.16.1</aws.java.sdk2.version>
     <jaxb-api>2.3.1</jaxb-api>

--- a/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
@@ -75,7 +75,7 @@ public abstract class PulsarTestBase {
         log.info("-------------------------------------------------------------------------");
 
 
-        final String pulsarImage = System.getProperty("pulsar.systemtest.image", "streamnative/pulsar:2.9.2.13");
+        final String pulsarImage = System.getProperty("pulsar.systemtest.image", "apachepulsar/pulsar:latest");
         pulsarService = new PulsarContainer(DockerImageName.parse(pulsarImage));
         pulsarService.waitingFor(new HttpWaitStrategy()
                 .forPort(BROKER_HTTP_PORT)

--- a/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/PulsarTestBase.java
@@ -75,7 +75,7 @@ public abstract class PulsarTestBase {
         log.info("-------------------------------------------------------------------------");
 
 
-        final String pulsarImage = System.getProperty("pulsar.systemtest.image", "apachepulsar/pulsar:latest");
+        final String pulsarImage = System.getProperty("pulsar.systemtest.image", "apachepulsar/pulsar:2.9.2");
         pulsarService = new PulsarContainer(DockerImageName.parse(pulsarImage));
         pulsarService.waitingFor(new HttpWaitStrategy()
                 .forPort(BROKER_HTTP_PORT)

--- a/src/test/java/org/apache/pulsar/io/jcloud/container/PulsarContainer.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/container/PulsarContainer.java
@@ -32,9 +32,9 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
     public static final int BROKER_HTTP_PORT = 8080;
     public static final String METRICS_ENDPOINT = "/metrics";
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("streamnative/pulsar");
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("apachepulsar/pulsar");
     @Deprecated
-    private static final String DEFAULT_TAG = "2.8.1.6";
+    private static final String DEFAULT_TAG = "latest";
 
     private boolean functionsWorkerEnabled = false;
 
@@ -57,7 +57,7 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
     public PulsarContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
 
-        dockerImageName.assertCompatibleWith(DockerImageName.parse("streamnative/pulsar"));
+        dockerImageName.assertCompatibleWith(DockerImageName.parse("apachepulsar/pulsar"));
 
         withExposedPorts(BROKER_PORT, BROKER_HTTP_PORT);
         withCommand("/pulsar/bin/pulsar", "standalone", "--no-functions-worker", "-nss");

--- a/src/test/java/org/apache/pulsar/io/jcloud/container/PulsarContainer.java
+++ b/src/test/java/org/apache/pulsar/io/jcloud/container/PulsarContainer.java
@@ -34,7 +34,7 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("apachepulsar/pulsar");
     @Deprecated
-    private static final String DEFAULT_TAG = "latest";
+    private static final String DEFAULT_TAG = "2.8.1";
 
     private boolean functionsWorkerEnabled = false;
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

To address vulnerability CVE-2025-30065

### Modifications

Upgraded Following version - Parquet : 1.12.2 -> 1.15.1

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)
