### PR TITLE
Upgrade protobuf3 & async-http-client to address CVE-2024-7254 & CVE-2024-53990

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <commons-compress.version>1.26.0</commons-compress.version>
     <log4j.version>2.17.1</log4j.version>
     <json-smart.version>2.4.9</json-smart.version>
-    <protobuf3.version>3.19.6</protobuf3.version>
+    <protobuf3.version>3.25.5</protobuf3.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
     <grpc.version>1.42.1</grpc.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <log4j.version>2.17.1</log4j.version>
     <json-smart.version>2.4.9</json-smart.version>
     <protobuf3.version>3.25.5</protobuf3.version>
+    <asynchttpclient.version>2.12.4</asynchttpclient.version>
     <protoc3.version>${protobuf3.version}</protoc3.version>
     <grpc.version>1.42.1</grpc.version>
     <protoc-gen-grpc-java.version>${grpc.version}</protoc-gen-grpc-java.version>
@@ -167,6 +168,11 @@
             <artifactId>avro</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.asynchttpclient</groupId>
+        <artifactId>async-http-client</artifactId>
+        <version>${asynchttpclient.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,10 +169,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <!-- Override transitive dependency version to fix vulnerability -->
       <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
         <version>${asynchttpclient.version}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
### Motivation

protobuf3 3.19.6 contains CVE-2024-7254 vulnerability and its fixed in 3.25.5.
async-http-client has CVE-2024-53990 and its fixed in 2.12.4

### Modifications

Upgraded Following version
 - protobuf3 : 3.19.6 -> 3.25.5
 - async-http-client -> 2.12.4

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [x] `no-need-doc`

  (Please explain why)

- [ ] `doc`
